### PR TITLE
Fix double slash in GOPATH env var

### DIFF
--- a/goswitch
+++ b/goswitch
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 CMD=$(basename $0)
-_ROOT="$HOME/.go/"
+_ROOT="$HOME/.go"
 _GOROOTPATH=${_ROOT}/go/root
 _GOPATH=${_ROOT}/go/path
 

--- a/goswitch
+++ b/goswitch
@@ -4,6 +4,7 @@ CMD=$(basename $0)
 _ROOT="$HOME/.go"
 _GOROOTPATH=${_ROOT}/go/root
 _GOPATH=${_ROOT}/go/path
+SYSTEM="$(echo $(uname -s) | tr '[A-Z]' '[a-z]')"
 
 setpath(){
     VERSION=$1
@@ -26,7 +27,7 @@ setpath(){
         esac
     fi
 
-    echo "# you must call eval \$("$(basename $0)" use ${VERSION})"
+    echo "# you must call eval \"\$("$(basename $0)" use ${VERSION})\""
     [ -d ${GOROOT} ] && echo "export GOROOT=${GOROOT}; export PATH=\$GOROOT/bin:\$PATH"
     [ -d ${GOPATH} ] && echo "export GOPATH=${GOPATH}; export PATH=\$GOPATH/bin:\$PATH"
 
@@ -55,7 +56,7 @@ EOF
 install_go(){
     echo "install go $1"
     VERSION=$1
-    u="https://storage.googleapis.com/golang/go${VERSION}.linux-amd64.tar.gz"
+    u="https://storage.googleapis.com/golang/go${VERSION}.${SYSTEM}-amd64.tar.gz"
     echo "Downloading $u"
     GOROOT=${_GOROOTPATH}/go-${VERSION}
     [ -d ${GOROOT} ] && echo -e "\E[32m$GOROOT already exists, if you want to reinstall, please remove that directory first\E[0m" && exit 1


### PR DESCRIPTION
Example:

```sh
# before
/home/username/.go//go/root/go-1.9.2
# after
/home/username/.go/go/root/go-1.9.2
```